### PR TITLE
Bump org.apache.maven.plugins:maven-surefire-plugin from 3.2.5 to 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.2.5</version>
+          <version>3.5.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
### Description

In this pull request, the version of the `maven-surefire-plugin` in the `pom.xml` file is being updated from `3.2.5` to `3.5.0`.

- Update the version of the `maven-surefire-plugin` from `3.2.5` to `3.5.0` in the `pom.xml` file.