### PR TITLE
Bump org.apache.maven.plugins:maven-clean-plugin from 3.3.2 to 3.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
         <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>3.3.2</version>
+          <version>3.4.0</version>
         </plugin>
         <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
         <plugin>


### PR DESCRIPTION
### Description

The version of the maven-clean-plugin in the pom.xml file has been updated from 3.3.2 to 3.4.0.

Summary of changes:
- Updated the version of the maven-clean-plugin in the pom.xml from 3.3.2 to 3.4.0.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Bump the version of `maven-clean-plugin` from 3.3.2 to 3.4.0 in the `pom.xml` file.

### Why are these changes being made?

This update ensures compatibility with the latest features and bug fixes provided in version 3.4.0 of the `maven-clean-plugin`, improving the build process and maintaining the project&#x27;s dependencies up-to-date.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->